### PR TITLE
Use the joomla/coding-standards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && export COMPOSER_HOME=/usr/local \
-    && composer global require squizlabs/php_codesniffer:~1.5 \
+    && composer global require joomla/coding-standards "~2.0@alpha" \
     && echo 'export PATH=/usr/local/vendor/bin:$PATH' >> $HOME/.bashrc \
     && mkdir -p /root/.composer/vendor/bin/ \
     && ln -s /usr/local/vendor/bin/phpcs /root/.composer/vendor/bin/phpcs


### PR DESCRIPTION
joomla/coding-standards are dependent on PHPCS so PHPCS should automatically be installed with it.

This should be the basic change for using the joomla/coding-standards. Note: I haven't used docker so I haven't tested the change. 
There is likely a set needed to install the Joomla standard and the example ruleset for the CMS in PHPCS. so that if you checked PHPCS for installed standards you would see something like
```sh
The installed coding standards are MySource, PEAR, PHPCS, PSR1, PSR2, Squiz, Zend, Joomla and Joomla-CMS
```

On travis I did this with 
```sh
libraries/vendor/bin/phpcs --config-set installed_paths libraries/vendor/joomla/coding-standards,libraries/vendor/joomla/coding-standards/ExampleRulesets/
```
